### PR TITLE
Output improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ option like this:
         "action": "\\bitExpert\\CaptainHook\\Infection\\InfectionAction",
         "options": {
             "args": [
-                "-j 4"
+                "-j4"
             ]
         }
       }

--- a/src/bitExpert/CaptainHook/Infection/InfectionAction.php
+++ b/src/bitExpert/CaptainHook/Infection/InfectionAction.php
@@ -61,6 +61,10 @@ class InfectionAction implements Action
 
             throw new ActionFailed($errorMessage);
         }
+
+        if (!empty($result->getStdOut())) {
+            $io->write($result->getStdOut());
+        }
     }
 
     /**

--- a/src/bitExpert/CaptainHook/Infection/InfectionAction.php
+++ b/src/bitExpert/CaptainHook/Infection/InfectionAction.php
@@ -49,8 +49,17 @@ class InfectionAction implements Action
 
         $result = $this->invokeInfectionProcess($infectionCli, $infectionArgs);
         if (!$result->isSuccessful()) {
-            $io->writeError($result->getStdOut());
-            throw new ActionFailed("Running Infection failed! Check error output above");
+            $errorMessage = '<error>Running Infection failed!</error>';
+
+            if (!empty($result->getStdOut())) {
+                $errorMessage .= PHP_EOL . $result->getStdOut();
+            }
+
+            if (!empty($result->getStdErr())) {
+                $errorMessage .= PHP_EOL . $result->getStdErr();
+            }
+
+            throw new ActionFailed($errorMessage);
         }
     }
 

--- a/tests/bitExpert/CaptainHook/Infection/InfectionActionUnitTest.php
+++ b/tests/bitExpert/CaptainHook/Infection/InfectionActionUnitTest.php
@@ -83,15 +83,13 @@ class InfectionActionUnitTest extends TestCase
     public function failingInfectionWillThrowException()
     {
         $this->expectException(ActionFailed::class);
+        $this->expectExceptionMessageMatches('/<error>.+<\/error>\noutput\nerror/');
 
-        $result = new Result('./vendor/bin/infection', 1);
+        $result = new Result('./vendor/bin/infection', 1, 'output', 'error');
 
         $this->hook->expects(self::once())
             ->method('invokeInfectionProcess')
             ->willReturn($result);
-
-        $this->io->expects(self::once())
-            ->method('writeError');
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
     }
@@ -139,11 +137,11 @@ class InfectionActionUnitTest extends TestCase
 
         $this->action->expects(self::once())
             ->method('getOptions')
-            ->willReturn(new Options(['args' => ['-j 4']]));
+            ->willReturn(new Options(['args' => ['-j4']]));
 
         $this->hook->expects(self::once())
             ->method('invokeInfectionProcess')
-            ->with('./vendor/bin/infection', ['-j 4'])
+            ->with('./vendor/bin/infection', ['-j4'])
             ->willReturn($result);
 
         $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
@@ -158,7 +156,7 @@ class InfectionActionUnitTest extends TestCase
 
         $this->action->expects(self::once())
             ->method('getOptions')
-            ->willReturn(new Options(['args' => '-j 4']));
+            ->willReturn(new Options(['args' => '-j4']));
 
         $this->hook->expects(self::once())
             ->method('invokeInfectionProcess')

--- a/tests/bitExpert/CaptainHook/Infection/InfectionActionUnitTest.php
+++ b/tests/bitExpert/CaptainHook/Infection/InfectionActionUnitTest.php
@@ -80,6 +80,24 @@ class InfectionActionUnitTest extends TestCase
     /**
      * @test
      */
+    public function outputFromInfectionShouldBePrinted()
+    {
+        $result = new Result('./vendor/bin/infection', 0, 'output');
+
+        $this->hook->expects(self::once())
+            ->method('invokeInfectionProcess')
+            ->willReturn($result);
+
+        $this->io->expects(self::once())
+            ->method('write')
+            ->with('output');
+
+        $this->hook->execute($this->config, $this->io, $this->repository, $this->action);
+    }
+
+    /**
+     * @test
+     */
     public function failingInfectionWillThrowException()
     {
         $this->expectException(ActionFailed::class);


### PR DESCRIPTION
Hey,

I had just installed the action and let it run. It failed with "Running Infection failed! Check error output above" but there wasn't any output. I've added stdout/err to the exception message similar to how Sebastian is doing it. After changing it I discovered that the cause of the error was the `-j 4` I copy/pasted from the README. It actually has to be `-j4` or `-j=4`. I changed that in the docs and tests. It doesn't really matter for the latter but I like to keep it straight.

I also print the output of infection so the developer can see the results.