### PR TITLE
PHP 8.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
         composer-prefer-lowest: [false]
         coveralls: [false]
         include:
           - operating-system: 'ubuntu-latest'
-            php-versions: '8.1'
+            php-versions: '8.2'
             coveralls: true
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,5 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer require php-coveralls/php-coveralls
-          ./vendor/bin/php-coveralls --coverage_clover=clover.xml -v
+          composer require php-coveralls/php-coveralls --with-all-dependencies
+          php ./vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -11,21 +11,21 @@
         }
     ],
     "require": {
-        "php": "^7.4.0|^8.0.0|^8.1.0",
-        "captainhook/captainhook": "^5.10.8"
+        "php": "^8.0.0|^8.1.0|^8.2.0",
+        "captainhook/captainhook": "^5.12.0"
     },
     "require-dev": {
         "captainhook/plugin-composer": "^5.3.3",
-        "infection/infection": "^0.21.5",
-        "madewithlove/license-checker": "^0.10.0",
-        "phly/keep-a-changelog": "^2.11",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.5.4",
-        "phpstan/phpstan-phpunit": "^1.1.0",
-        "phpstan/phpstan-strict-rules": "^1.1.0",
-        "phpunit/phpunit": "^9.5.20",
+        "infection/infection": "^0.26.16",
+        "madewithlove/license-checker": "^1.3",
+        "phly/keep-a-changelog": "^2.12.1",
+        "phpstan/extension-installer": "^1.2.0",
+        "phpstan/phpstan": "^1.9.4",
+        "phpstan/phpstan-phpunit": "^1.3.3",
+        "phpstan/phpstan-strict-rules": "^1.4.4",
+        "phpunit/phpunit": "^9.5.27",
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "^3.6.2"
+        "squizlabs/php_codesniffer": "^3.7.1"
     },
     "autoload" : {
         "psr-4" : {

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -6,8 +6,8 @@
     },
     "logs": {
         "text": "infection.log",
-        "badge": {
-            "branch": "master"
+        "stryker": {
+            "badge": "master"
         }
     },
     "mutators": {


### PR DESCRIPTION
Make the extension work on PHP 8.2 and drop support for PHP 7.4 to make maintenance easier.